### PR TITLE
Fix empty $pgvm_home env variable

### DIFF
--- a/bin/pgvm-self-install
+++ b/bin/pgvm-self-install
@@ -42,7 +42,7 @@ force_clone_repo()
 
 set_bashrc_env()
 {
-	pgvm_home="export pgvm_home=\$pgvm_home"
+	pgvm_home="export pgvm_home=$pgvm_home"
 	path="export PATH=\$pgvm_home/bin:\$PATH"
 	path_env="export PATH=\$pgvm_home/environments/current/bin:\$PATH"
 


### PR DESCRIPTION
After the commit 76bbde624f8434b4bc3d28e037dd99e4cc99f464 the pgvm command fails with "pgvm: command not found" message on my ubuntu.

I think this happens because we are escaping the $pgvm_home variable when defining it [1], so I requesting this pull to fix it.

[1] https://github.com/guedes/pgvm/commit/76bbde624f8434b4bc3d28e037dd99e4cc99f464#L4R45
