### PR TITLE
ajustando o teste de checksum para ambos os formatos de md5 baixados do ...

### DIFF
--- a/actions/contrib
+++ b/actions/contrib
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+
+source $pgvm_home/actions/current
+
+usage()
+{
+    echo """
+Manipulates PostgreSQL contribs with pgvm.
+
+Usage: pgvm contrib <action> [ contrib-name | all ]
+
+  - action
+
+    install     Install a crontrib using current version
+
+"""
+}
+
+install() {
+    contrib_name="$(echo "${1}" | awk '{print tolower($0)}')"
+
+    make_dir="${pgvm_home}/src/postgresql-$(current_version)/contrib"
+
+    if [ "${contrib_name}X" = "X" ]; then
+        usage && exit
+    elif [ "${contrib_name}" != "all" ]; then
+        make_dir="${make_dir}/${contrib_name}"
+
+        test_if_exists "${make_dir}" ; status=$? ; [[ ${status} -ne 0 ]] && exit ${status}
+    fi
+
+    ## do the installing
+    cd ${make_dir}
+    if [ ${contrib_name} = "all" ]; then
+        echo "Installing all contribs."
+    else
+        echo "Installing contrib ${contrib_name}."
+    fi
+    
+    make clean 1> make_clean.log 2>&1
+    make 1> make.log 2>&1
+    make install 1> make_install.log 2>&1
+    if [ ${?} -ne 0 ]; then
+        echo "ERROR: Fail to compile contrib. See '"${make_dir}/make_install.log"' for details."
+    fi
+}
+
+contrib() {
+    case $1 in
+        install)
+            install "$2"
+            ;;
+        *) usage  ;;
+    esac
+}
+
+test_if_exists() {
+    if [ ! -d "${1}" ]; then
+        echo "Contrib directory not found! Aborting."
+        exit 2
+    fi
+}

--- a/actions/help
+++ b/actions/help
@@ -36,6 +36,8 @@ Usage: pgvm action [arguments]
 
     cluster      Manipulate clusters (PGDATA directories)
 
+    contrib      Install PostgreSQL contrib modules
+
     console      Starts psql and connects to a specified cluster
 
     help         This help

--- a/include/helpers
+++ b/include/helpers
@@ -289,7 +289,13 @@ check_md5()
 
     case $OSTYPE in
         darwin*)
-                 [[ "$(cat ${pg_file}.md5 | cut -d' ' -f1)" == "$(md5 -r ${pg_file} | cut -d' ' -f1)" ]]
+
+            file_md5=$(cat ${pg_file}.md5 | awk '{print $1}' )
+            if [ $(egrep 'MD5 \(' ${pg_file}.md5  | wc -l) -eq 1 ]; then
+              file_md5=$(cat ${pg_file}.md5 | awk '{print $(NF)}' )
+            fi
+
+                 [[ "$file_md5" == "$(md5 -r ${pg_file} | awk '{print $1}')" ]]
 		 ;;
               *)
                  md5sum -c ${pg_file}.md5 >/dev/null 2>/dev/null


### PR DESCRIPTION
fiz um ajuste no teste do checksum, para o caso de o formato do arquivo estar diferente da saida padrão do md5 -r.

testei apenas no mac e parece estar ok.
