### PR TITLE
Attempt SSH, then HTTPS if GIT protocol fails

### DIFF
--- a/bin/pgvm-self-install
+++ b/bin/pgvm-self-install
@@ -28,7 +28,9 @@ clone_repo()
 {
   echo
   echo -n "wait while the installer fetches pgvm's files ..."
-  git clone git://github.com/guedes/pgvm.git $pgvm_home > /dev/null 2>&1 || {
+  git clone   git://github.com/guedes/pgvm.git $pgvm_home > /dev/null 2>&1 ||
+  git clone     git@github.com:guedes/pgvm.git $pgvm_home > /dev/null 2>&1 ||
+  git clone https://github.com/guedes/pgvm.git $pgvm_home > /dev/null 2>&1 || {
     echo "sorry, pgvm could not be installed" && exit 1
   }
 


### PR DESCRIPTION
I ran the install instructions from `README` in Ubuntu 14.04 (Trusty), and the `git://` address timed out. However, I successfully cloned it over SSH. I think it should fall back to other protocol options if the first one doesn't work, rather than just dying completely.
